### PR TITLE
removed dot/elementwise operator

### DIFF
--- a/case3/case3.jl
+++ b/case3/case3.jl
@@ -103,7 +103,7 @@ function trueODEfunc(dydt, y, k, t)
 end
 
 # Generate data sets
-u0_list .= 10 .^ (rand(Float32, (n_exp, ns)) * -3);
+u0_list = 10 .^ (rand(Float32, (n_exp, ns)) * -3);
 @. u0_list[[1, 2, end], [3, 5, 7, 9]] .*= 0.f0;
 # @. u0_list[:, [3, 5, 7, 9]] .*= 0.f0;
 # u0_list = rand(Float32, (n_exp, ns));


### PR DESCRIPTION
removed dot operato in case 3..
was resulting in following error in Julia 1.6
```julia
julia> # Generate data sets
       u0_list .= 10 .^ (rand(Float32, (n_exp, ns)) * -3);
ERROR: UndefVarError: u0_list not defined
Stacktrace:
 [1] top-level scope
   @ none:1

```